### PR TITLE
Issue #3. Find packages with underscore in the name

### DIFF
--- a/pip_module_scanner/scanner.py
+++ b/pip_module_scanner/scanner.py
@@ -20,7 +20,7 @@ class Scanner:
     def __init__(self, path=os.getcwd(), output=None):
 
         # Compiled import regular expression
-        self.import_statement = re.compile(r'(?:from|import) ([a-zA-Z0-9]+)(?:.*)')
+        self.import_statement = re.compile(r'(?:from|import) ([a-zA-Z0-9_]+)(?:.*)')
 
         # List of pip distributions
         # Called once and then imported for performance


### PR DESCRIPTION
Hi @Paradoxis,

This PR is to fix #3 

Scanner uses below regular expression to find import statements in the code.

` r'(?:from|import) ([a-zA-Z0-9]+)(?:.*)'`

This would cause packages with underscore to be cut off. For eg., `import cx_Oracle` will be identified as importing package "cx". I propose adding underscore in the regex as below. 

`r'(?:from|import) ([a-zA-Z0-9_]+)(?:.*)'`

Thanks